### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ Tom,Jones,Senior Director,buyer@salesforcesample.com,1940-06-07Z,"Self-described
 Ian,Dury,Chief Imagineer,cto@salesforcesample.com,,"World-renowned expert in fuzzy logic design. 
 Influential in technology purchases."
 ```
+
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`

--- a/actions/format.yaml
+++ b/actions/format.yaml
@@ -1,6 +1,6 @@
 ---
 name: format
-runner_type: run-python
+runner_type: python-script
 description: Format a Python list into a CSV string
 enabled: true
 entry_point: format.py

--- a/actions/parse.yaml
+++ b/actions/parse.yaml
@@ -1,6 +1,6 @@
 ---
 name: parse
-runner_type: run-python
+runner_type: python-script
 description: Parse CSV string and return JSON object.
 enabled: true
 entry_point: parse.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - serialization
   - deserialization
   - text processing
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.