### PR TITLE
Add new csv.parse_file action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Change Log
 
+# 0.4.0
+
+- Add new `parse_file` action which operates on CSV files.
+
 # 0.3.0
 
 - Updated action `runner_type` from `run-python` to `python-script`
-

--- a/actions/parse_file.py
+++ b/actions/parse_file.py
@@ -12,7 +12,7 @@ __all__ = [
 class ParseCSVFileAction(Action):
     def run(self, file_path, delimiter=',', quote_char='"'):
         if not os.path.isfile(file_path):
-            raise ValueError('File "%s" doesnt exist')
+            raise ValueError('File "%s" doesnt exist' % (file_path))
 
         with open(file_path, 'r') as fp:
             content = fp.read()

--- a/actions/parse_file.py
+++ b/actions/parse_file.py
@@ -1,0 +1,27 @@
+import os
+import csv
+from StringIO import StringIO
+
+from st2actions.runners.pythonrunner import Action
+
+__all__ = [
+    'ParseCSVFileAction'
+]
+
+
+class ParseCSVFileAction(Action):
+    def run(self, file_path, delimiter=',', quote_char='"'):
+        if not os.path.isfile(file_path):
+            raise ValueError('File "%s" doesnt exist')
+
+        with open(file_path, 'r') as fp:
+            content = fp.read()
+
+        fh = StringIO(content)
+
+        reader = csv.reader(fh, delimiter=str(delimiter), quotechar=str(quote_char))
+
+        result = []
+        for row in reader:
+            result.append(row)
+        return result

--- a/actions/parse_file.py
+++ b/actions/parse_file.py
@@ -1,6 +1,5 @@
 import os
 import csv
-from StringIO import StringIO
 
 from st2actions.runners.pythonrunner import Action
 
@@ -14,14 +13,11 @@ class ParseCSVFileAction(Action):
         if not os.path.isfile(file_path):
             raise ValueError('File "%s" doesnt exist' % (file_path))
 
-        with open(file_path, 'r') as fp:
-            content = fp.read()
-
-        fh = StringIO(content)
-
-        reader = csv.reader(fh, delimiter=str(delimiter), quotechar=str(quote_char))
-
         result = []
-        for row in reader:
-            result.append(row)
+        with open(file_path, 'r') as fh:
+            reader = csv.reader(fh, delimiter=str(delimiter), quotechar=str(quote_char))
+
+            for row in reader:
+                result.append(row)
+
         return result

--- a/actions/parse_file.yaml
+++ b/actions/parse_file.yaml
@@ -1,7 +1,7 @@
 ---
-name: parse
+name: parse_file
 runner_type: python-script
-description: Parse file in a CSV format and return JSON object.
+description: Parse a file in CSV format and return JSON object.
 enabled: true
 entry_point: parse_file.py
 parameters:

--- a/actions/parse_file.yaml
+++ b/actions/parse_file.yaml
@@ -1,0 +1,21 @@
+---
+name: parse
+runner_type: python-script
+description: Parse file in a CSV format and return JSON object.
+enabled: true
+entry_point: parse_file.py
+parameters:
+  file_path:
+    type: string
+    description: Path to the file to parse.
+    required: true
+  delimiter:
+    type: string
+    description: String delimiter character.
+    required: false
+    default: ","
+  quote_char:
+    type: string
+    description: Character used to quote the strings.
+    required: false
+    default: "\""

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - serialization
   - deserialization
   - text processing
-version : 0.3.0
+version : 0.4.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This pull request adds `csv.parse_file` action.

This action works in the same manner as `csv.parse`, but it operates on a file instead of a string.

Resolves #2.