### PR TITLE
Fix actions so it works under Python 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.3
+
+- Fix ``csv.parse`` and ``csv.format`` action so they work under Python 3.
+
 # 0.4.2
 
 - Change format data param to type array.

--- a/actions/format.py
+++ b/actions/format.py
@@ -1,5 +1,6 @@
 import csv
-from StringIO import StringIO
+
+from six.moves import StringIO
 
 from st2common.runners.base_action import Action
 from st2common.exceptions.action import InvalidActionParameterException

--- a/actions/parse.py
+++ b/actions/parse.py
@@ -1,5 +1,6 @@
 import csv
-from StringIO import StringIO
+
+from six.moves import StringIO
 
 from st2common.runners.base_action import Action
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - serialization
   - deserialization
   - text processing
-version: 0.4.2
+version: 0.4.3
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This pull request fixes ``csv.parse`` and ``csv.format`` action so they work under Python 3.