### PR TITLE
Bump up version to fix pack index version issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.5
+
+- Version bump to fix index.json version issue for ``csv``
+
 # 0.4.4
 
 - Version bump to fix tagging issue

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - serialization
   - deserialization
   - text processing
-version: 0.4.4
+version: 0.4.5
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
Pack index file (https://index.stackstorm.org/v1/index.json) for `csv`  version is  `0.1.0` and it is not up to date. When we working on https://github.com/StackStorm/st2/pull/4743, it failed on CICD test.

With test `tests.test_run_pack_tests_tool` task `install_pack_1`, it run action `st2 pack install csv`. With new code changes, it installed the latest version from the index file which is `0.1.0`, it failed on creating virtualenv with `RunnerType run-python is not found`.  Without new code, it installs from `master` with version is `0.4.4`.  

Open this PR try to debug why `csv` pack version is not up to date in pack index file.  